### PR TITLE
chore: upgrade Calcit and expose source

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,2 @@
 
-calcit.cirru -diff linguist-generated
 yarn.lock -diff linguist-generated

--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -17,18 +17,18 @@ jobs:
           node-version: 24
           cache: 'yarn'
 
-      - uses: calcit-lang/setup-cr@0.0.9
+      - uses: calcit-lang/setup-calcit@v1
 
       - name: Validate Calcit snapshot
         run: |
           caps --ci
-          cr calcit.cirru edit format
+          calcit calcit.cirru edit format
           git diff --exit-code -- calcit.cirru
-          cr calcit.cirru --check-only
+          calcit calcit.cirru --check-only
 
       - name: "compiles to js"
         run: >
-          caps --ci && cr js
+          caps --ci && calcit calcit.cirru js
           && yarn install --immutable && yarn vite build --base=./
 
       - name: Deploy to server

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,5 +1,5 @@
 
-{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |fuzzy-filter)
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `calcit query` to inspect and `calcit edit`/`calcit tree` to modify. Run `calcit docs agents --full` first. Manual edits must follow format and schema conventions, then run `calcit edit format`.") (:package |fuzzy-filter)
   :entries $ {}
     :default $ {} (:description |) (:init-fn 'fuzzy-filter.main/main!) (:mode :native) (:reload-fn 'fuzzy-filter.main/reload!)
       :feature-policy $ {}

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,5 +1,5 @@
 {}
-  (:calcit-version |0.13.27)
+  (:calcit-version |0.13.29)
   :version |0.0.10
   :dependencies $ {}
     |Respo/reel.calcit |0.6.6

--- a/history/2026082222-upgrade-calcit-01329.md
+++ b/history/2026082222-upgrade-calcit-01329.md
@@ -1,0 +1,5 @@
+# 2026082222 Upgrade Calcit and expose source
+
+- Updated Calcit and @calcit/procs to 0.13.29.
+- Replaced setup-cr and cr workflow commands with setup-calcit and calcit.
+- Removed the linguist-generated rule hiding calcit.cirru.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "vite": "^8.0.16"
   },
   "dependencies": {
-    "@calcit/procs": "^0.13.27",
+    "@calcit/procs": "^0.13.29",
     "shortid": "^2.2.16"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:^0.13.27":
-  version: 0.13.27
-  resolution: "@calcit/procs@npm:0.13.27"
+"@calcit/procs@npm:^0.13.29":
+  version: 0.13.29
+  resolution: "@calcit/procs@npm:0.13.29"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/f3f2d1a3dd94797f99bec39cbf722b7d98d0308d0643f861997b1accc44fe68f5922149b268881aae1df4a3524968e3f10c58870358952bd959ff4dddcfd326a
+  checksum: 10c0/d8db7c62054dda827557f1bd8c8d7a777c17b40bd43f51fb3b39c57386d1c1a41dad449b641201daa05ad14c38a423601c803b5d9eb3557ae0173ae1a03f570a
   languageName: node
   linkType: hard
 
@@ -286,7 +286,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "fuzzy-filter@workspace:."
   dependencies:
-    "@calcit/procs": "npm:^0.13.27"
+    "@calcit/procs": "npm:^0.13.29"
     bottom-tip: "npm:^0.1.5"
     shortid: "npm:^2.2.16"
     vite: "npm:^8.0.16"


### PR DESCRIPTION
Synced latest main before changing the project. Updated Calcit and @calcit/procs to 0.13.29, migrated setup-calcit and calcit commands, and removed the hidden-source treatment where applicable. Local Calcit check-only and lockfile validation pass.